### PR TITLE
fix CLI options documentation incongruity

### DIFF
--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ var opts struct {
 	Profile string `short:"p" long:"profile" description:"Write profile to given file path"`
 
 	// FPS
-	FPS int `long:"fps" description:"required FPS, must be somewhere between 1 and 50" default:"25"`
+	FPS int `long:"fps" description:"required FPS, must be somewhere between 1 and 60" default:"25"`
 }
 
 // array with half width kanas as Go runes


### PR DESCRIPTION
FPS is checked in `main()` to see if it is between 0 and 60, not 0 and 50, as the docs say.
