### PR TITLE
Use Tcell for more goodness

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,4 @@
+Copyright 2015 Garrett D'Amore
 Copyright (c) 2013, Geert-Johan Riemer
 All rights reserved.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+## THIS IS A FORK of github.com/GeertJohan/gomatrix
+
+> _This fork uses github.com/gdamore/tcell
+> It offers better (nicer/richer) colors and can work on terminals that don't
+> support Unicode.  For example, it works on GB18030, and EUC-JP terminals.
+> If your environment is not UTF-8 compliant, the glyphs will be replaced with
+> "?"'s by default.  Press "a" to see ASCII in that case._
+
 ## gomatrix
 gomatrix connects to The Matrix and displays it's data streams in your terminal.
 

--- a/main.go
+++ b/main.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/jessevdk/go-flags"
-	"github.com/nsf/termbox-go"
+	"github.com/gdamore/tcell/termbox"
 )
 
 // command line flags variable

--- a/stream.go
+++ b/stream.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/nsf/termbox-go"
+	"github.com/gdamore/tcell/termbox"
 )
 
 // Stream updates a StreamDisplay with new data updates

--- a/stream.go
+++ b/stream.go
@@ -26,15 +26,15 @@ func (s *Stream) run() {
 		Foreground(tcell.ColorBlack).
 		Background(tcell.ColorBlack)
 
-	headStyle := blackStyle.Foreground(tcell.ColorWhite)
+	headStyle := blackStyle.Foreground(tcell.ColorSilver)
 	tailStyle := blackStyle.Foreground(tcell.ColorGreen)
 	midStyle := blackStyle.Foreground(tcell.ColorGreen)
 
 	if screen.Colors() >= 16 {
-		midStyle = headStyle.Foreground(tcell.ColorBrightGreen)
+		midStyle = headStyle.Foreground(tcell.ColorLime)
 		// 33% of streams (arbitrary) get a bright white head
 		if rand.Intn(100) < 33 {
-			headStyle = headStyle.Foreground(tcell.ColorBrightWhite)
+			headStyle = headStyle.Foreground(tcell.ColorWhite)
 		} else {
 			headStyle = midStyle
 		}


### PR DESCRIPTION
I'm posting this here mostly for information; whether you choose to accept this PR is entirely up to you -- I have no particular vested interest.

The commit comments are pretty clear -- apart from greater portability and usability on non-UTF-8 terminals, the main benefit is a little fancier display on nicer terminals.  In particular, I use bright green for the first two elements in every stream, and for roughly 33% of them I actually make the first glyph bright white.  This is possible because Tcell has a richer understanding of colors.  Note that on terminals with fewer than 16 colors we still use your original color scheme.

I also fixed your event loop to not use an anonymous function -- instead its a flag variable, so we don't even need to have a label.

Oh, and thanks for doing the original work here.  Its pretty cool.  :-) 