### PR TITLE
updates dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,12 @@
-FROM golang:1-onbuild
+FROM golang:alpine as builder
+RUN apk update && apk upgrade && apk add --no-cache git
+ADD ./ ./gomatrix
+RUN mkdir /build
+WORKDIR ./gomatrix
+ENV GOOS=linux GOARCH=amd64 CGO_ENABLED=0
+RUN go build -a -ldflags="-w -s" -installsuffix cgo -o /build/gomatrix .
+
+FROM scratch
 MAINTAINER Geert-Johan Riemer <geertjohan@geertjohan.net>
+COPY --from=builder /build/gomatrix /gomatrix
+ENTRYPOINT ["/gomatrix"]


### PR DESCRIPTION
* removes deprecated onbuild image
* reduces image layers from 11 to 1
* reduces size from 761MB to 3.74MB