### PR TITLE
update installation command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 gomatrix connects to The Matrix and displays it's data streams in your terminal.
 
 ### Installation
-Install from source with `go get github.com/GeertJohan/gomatrix`
+Install from source with `go install github.com/GeertJohan/gomatrix@latest`
 
 ### Usage
 Just run `gomatrix`. Use `gomatrix --help` to view all options.


### PR DESCRIPTION
since go 1.16 the way to build and install packages is with install instead of get, go get does not work and install commands needs a version, hence the latest tag.

https://stackoverflow.com/a/24878851/18806702