### PR TITLE
Fix for #16

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -77,7 +77,9 @@ STREAM:
 		}
 	}
 
+	s.display.streamsLock.Lock()
 	delete(s.display.streams, s)
+	s.display.streamsLock.Unlock()
 }
 
 // StreamDisplay represents a vertical line in the terminal on which `Stream`s are displayed.


### PR DESCRIPTION
The crash in #16 is caused by an unguarded map access. The error is easy to reproduce by removing all delays in gomatrix and let it run for a few seconds.

This PR is tested by running with no delays for hours.